### PR TITLE
Use correctly typed missing values

### DIFF
--- a/R/ckd.R
+++ b/R/ckd.R
@@ -685,7 +685,7 @@ GFR_staging.numeric <- function(GFR, ...) {
     GFR >= 30 ~ GFR_stages[4],
     GFR >= 15 ~ GFR_stages[5],
     GFR >= 0 ~ GFR_stages[6],
-    TRUE ~ NA_integer_ # GFR should be positive
+    TRUE ~ GFR_stages[NA_integer_] # GFR should be positive
   )
 }
 

--- a/tests/testthat/test-aki.R
+++ b/tests/testthat/test-aki.R
@@ -92,9 +92,9 @@ aki_test_df <- function(env = parent.frame()) {
       values_to = "aki_"
     ) %>%
     dplyr::mutate(
-      SCr_ = dplyr::if_else(grepl("bCr|SCr", aki_staging_type), SCr_, NA_real_),
-      bCr_ = dplyr::if_else(grepl("bCr", aki_staging_type), bCr_, NA_real_),
-      UO_ = dplyr::if_else(grepl("UO", aki_staging_type), UO_, NA_real_)
+      SCr_ = dplyr::if_else(grepl("bCr|SCr", aki_staging_type), SCr_, SCr_[NA_integer_]),
+      bCr_ = dplyr::if_else(grepl("bCr", aki_staging_type), bCr_, bCr_[NA_integer_]),
+      UO_ = dplyr::if_else(grepl("UO", aki_staging_type), UO_, UO_[NA_integer_])
     ) %>%
     dplyr::filter(!is.na(aki_))
 }

--- a/tests/testthat/test-ckd.R
+++ b/tests/testthat/test-ckd.R
@@ -106,9 +106,9 @@ eGFR_df <- function(env = parent.frame()) {
     ) %>%
     dplyr::mutate(
       pediatric = grepl("child", eGFR_calc_type),
-      SCr = dplyr::if_else(grepl("SCr", eGFR_calc_type), SCr, NA_real_),
-      SCysC = dplyr::if_else(grepl("SCysC", eGFR_calc_type), SCysC, NA_real_),
-      BUN = dplyr::if_else(grepl("BUN", eGFR_calc_type), BUN, NA_real_),
+      SCr = dplyr::if_else(grepl("SCr", eGFR_calc_type), SCr, SCr[NA_integer_]),
+      SCysC = dplyr::if_else(grepl("SCysC", eGFR_calc_type), SCysC, SCysC[NA_integer_]),
+      BUN = dplyr::if_else(grepl("BUN", eGFR_calc_type), BUN, BUN[NA_integer_]),
       Age = dplyr::if_else(pediatric, units::set_units(10, "years"), Age)
     ) %>%
     dplyr::filter(!is.na(eGFR)) %>%


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

- `case_when()` and `if_else()` now use vctrs, which generally makes them more permissive when there are varying types, but in your case there is no common type between `<units>` and `<double>` so we need to use a typed units missing value

In dev dplyr, you could just do `NA` but that won't work with CRAN dplyr.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package in ahead of time! Thanks!