### PR TITLE
fix units check for upcoming version of units

### DIFF
--- a/R/ckd.R
+++ b/R/ckd.R
@@ -667,7 +667,7 @@ GFR_staging.data.frame <- function(.data, GFR, ...) {
 #' @rdname GFR_staging
 #' @export
 GFR_staging.units <- function(GFR, ...) {
-  if (grepl("1.73m2-1", units::deparse_unit(GFR))) {
+  if (units(GFR) == units(units::as_units("mL/min/1.73m2"))) {
     GFR <- GFR * units::set_units(1, "1.73m2")
   }
   GFR_staging(


### PR DESCRIPTION
As reported in https://github.com/r-quantities/units/pull/416, there are test failures for this package with the upcoming tokenizer in {units}. In any case, it is not a good idea to grep the deparsed string, because this may change and will change with the new version. This PR makes the check more robust by comparing the units of the input with some known units.